### PR TITLE
Update gem-maven-plugin.version to 1.0.0-rc4 for Maven 3.1 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <!-- versions -->
     <java.level>1.6</java.level>
     <vagrant.version>1.0.7</vagrant.version>
-    <gem-maven-plugin.version>1.0.0-beta</gem-maven-plugin.version>
+    <gem-maven-plugin.version>1.0.0-rc4</gem-maven-plugin.version>
     <maven-plugin-tools-javadoc.version>3.2</maven-plugin-tools-javadoc.version>
 
     <!-- integration tests settings -->


### PR DESCRIPTION
Please merge this and bump plugin version, this will enable Maven 3.1 users to use your plugin.
Thanks!
